### PR TITLE
Changes for LTC6802-1 (mostly)

### DIFF
--- a/src/LTC6802.cpp
+++ b/src/LTC6802.cpp
@@ -23,12 +23,9 @@ void LTC6802::initSPI(const byte pinMOSI, const byte pinMISO, const byte pinCLK)
   pinMode(pinMISO, INPUT);
   pinMode(pinCLK, OUTPUT);
 
-  //SPI.setBitOrder(MSBFIRST);
-  //SPI.setDataMode(SPI_MODE3);
-  //SPI.setClockDivider(SPI_CLOCK_DIV16);
-  //SPI.setBitOrder(MSBFIRST);
-  //SPI.setDataMode(SPI_MODE3);
-  //SPI.setClockDivider(SPI_CLOCK_DIV128);
+  // SPI.setBitOrder(MSBFIRST);
+  // SPI.setDataMode(SPI_MODE3);
+  // SPI.setClockDivider(SPI_CLOCK_DIV16);
   SPI.begin();
 
   // SPI.begin(ETHERNET_SHIELD_SPI_CS);

--- a/src/LTC6802.cpp
+++ b/src/LTC6802.cpp
@@ -23,9 +23,12 @@ void LTC6802::initSPI(const byte pinMOSI, const byte pinMISO, const byte pinCLK)
   pinMode(pinMISO, INPUT);
   pinMode(pinCLK, OUTPUT);
 
-  // SPI.setBitOrder(MSBFIRST);
-  // SPI.setDataMode(SPI_MODE3);
-  // SPI.setClockDivider(SPI_CLOCK_DIV16);
+  //SPI.setBitOrder(MSBFIRST);
+  //SPI.setDataMode(SPI_MODE3);
+  //SPI.setClockDivider(SPI_CLOCK_DIV16);
+  //SPI.setBitOrder(MSBFIRST);
+  //SPI.setDataMode(SPI_MODE3);
+  //SPI.setClockDivider(SPI_CLOCK_DIV128);
   SPI.begin();
 
   // SPI.begin(ETHERNET_SHIELD_SPI_CS);
@@ -71,20 +74,22 @@ void LTC6802::measure(const LTC6802::Commands cmd, const bool broadcast) const
  }
 
 template<std::size_t N>
-void LTC6802::read(const LTC6802::Commands cmd, std::array<byte, N> &arr) // TODO eliminate buffer overflow risk
+void LTC6802::read(const LTC6802::Commands cmd, std::array<byte, N> &arr, const bool broadcast) // TODO eliminate buffer overflow risk
   {
    SPI.beginTransaction(SPISettings(1000000, MSBFIRST, SPI_MODE3));
    digitalWrite(csPin, LOW);
-   if (true)
+   if (!broadcast)
     {
      SPI.transfer(this->address); // TODO broadcast
     }
+    
    SPI.transfer(static_cast<byte>(cmd));
 
    for (auto &element : arr)
     {
      element = SPI.transfer(static_cast<byte>(cmd));
     }
+    
    /* byte pec = */ SPI.transfer(static_cast<byte>(cmd));
 
    digitalWrite(csPin, HIGH);
@@ -92,19 +97,19 @@ void LTC6802::read(const LTC6802::Commands cmd, std::array<byte, N> &arr) // TOD
   }
 
 template<std::size_t N>
-void LTC6802::readValues(const LTC6802::Commands cmd, std::array<byte, N> &arr)
+void LTC6802::readValues(const LTC6802::Commands cmd, std::array<byte, N> &arr, const bool broadcast)
  {
   do
    {
-    read(cmd, arr);
+    read(cmd, arr, broadcast);
    }
   while (arr[0] == 0xff);
  }
 
 
- void LTC6802::flagsRead()
+ void LTC6802::flagsRead(const bool broadcast)
   {
-   read(RDFLG, this->regs.FLGRx);
+   read(RDFLG, this->regs.FLGRx, broadcast);
   }
 
 
@@ -119,11 +124,26 @@ void LTC6802::readValues(const LTC6802::Commands cmd, std::array<byte, N> &arr)
   }
 
 
-void LTC6802::cfgRead()
+void LTC6802::cfgRead(const bool broadcast)
  {
-  read(RDCFG, this->regs.CFGRx);
+  read(RDCFG, this->regs.CFGRx, broadcast);
  }
 
+bool LTC6802::pollADC(const bool broadcast) const
+{
+  bool busy;
+  SPI.beginTransaction(SPISettings(1000000, MSBFIRST, SPI_MODE3));
+  digitalWrite(csPin, LOW);
+  if (!broadcast)
+   {
+    SPI.transfer(this->address);
+   }
+  SPI.transfer(static_cast<byte>(PLADC));
+  busy = SPI.transfer(static_cast<byte>(PLADC));
+  digitalWrite(csPin, HIGH);
+  SPI.endTransaction();
+  return busy;
+}
 
 void LTC6802::cfgWrite(const bool broadcast) const
  {
@@ -195,6 +215,16 @@ void LTC6802::cfgSetGPIO2(const bool gpio)
   regs.CFGRx[CFGR0] = (regs.CFGRx[CFGR0] & CFG0_GPIO2_INVMSK) | (gpio << CFG0_GPIO2_Pos);
  }
 
+bool LTC6802::cfgGetCELL10() const
+ {
+  return (regs.CFGRx[CFGR0] & CFG0_CELL10_MSK);
+ }
+
+
+void LTC6802::cfgSetCELL10(const bool cell10)
+ {
+  regs.CFGRx[CFGR0] = (regs.CFGRx[CFGR0] & CFG0_CELL10_INVMSK) | (cell10 << CFG0_CELL10_Pos);
+ }
 
 bool LTC6802::cfgGetLVLPL() const
  {
@@ -273,15 +303,15 @@ void LTC6802::cfgSetVOV(const float vov) // TODO float vs double
  }
 
 
-void LTC6802::temperatureMeasure()
+void LTC6802::temperatureMeasure(const bool broadcast)
  {
-  measure(STTMPAD, false);
+  measure(STTMPAD, broadcast);
  }
 
 
-void LTC6802::temperatureRead()
+void LTC6802::temperatureRead(const bool broadcast)
  {
-  readValues(RDTMP, this->regs.TMPRx);
+  readValues(RDTMP, this->regs.TMPRx, broadcast);
  }
 
 
@@ -316,17 +346,37 @@ void LTC6802::temperatureDebugOutput() const
  }
 
 
-void LTC6802::cellsMeasure()
+void LTC6802::cellsMeasure(const bool broadcast)
  {
-  measure(STCVAD, false);
+  measure(STCVAD, broadcast);
  }
 
 
-void LTC6802::cellsRead()
+void LTC6802::cellsRead(const bool broadcast)
  {
-  readValues(RDCV, this->regs.CVRxx);
+  readValues(RDCV, this->regs.CVRxx, broadcast);
  }
 
+void LTC6802::getVolts(std::array<word, maxCells> &cellvolts) const
+ {
+  cellvolts[0] = regs.CVRxx[CVR00] | ((regs.CVRxx[CVR01] & 0x0F) << 8);
+  cellvolts[1] = ((regs.CVRxx[CVR01] & 0xf0) >> 4) | (regs.CVRxx[CVR02] << 4);
+
+  cellvolts[2] = regs.CVRxx[CVR03] | ((regs.CVRxx[CVR04] & 0x0F) << 8);
+  cellvolts[3] = ((regs.CVRxx[CVR04] & 0xf0) >> 4) | (regs.CVRxx[CVR05] << 4);
+
+  cellvolts[4] = regs.CVRxx[CVR06] | ((regs.CVRxx[CVR07] & 0x0F) << 8);
+  cellvolts[5] = ((regs.CVRxx[CVR07] & 0xf0) >> 4) | (regs.CVRxx[CVR08] << 4);
+
+  cellvolts[6] = regs.CVRxx[CVR09] | ((regs.CVRxx[CVR10] & 0x0F) << 8);
+  cellvolts[7] = ((regs.CVRxx[CVR10] & 0xf0) >> 4) | (regs.CVRxx[CVR11] << 4);
+
+  cellvolts[8] = regs.CVRxx[CVR12] | ((regs.CVRxx[CVR13] & 0x0F) << 8);
+  cellvolts[9] = ((regs.CVRxx[CVR13] & 0xf0) >> 4) | (regs.CVRxx[CVR14] << 4);
+
+  cellvolts[10] = regs.CVRxx[CVR15] | ((regs.CVRxx[CVR16] & 0x0F) << 8);
+  cellvolts[11] = ((regs.CVRxx[CVR16] & 0xf0) >> 4) | (regs.CVRxx[CVR17] << 4);
+ }
 
 void LTC6802::cellsDebugOutput() const
  {

--- a/src/LTC6802.h
+++ b/src/LTC6802.h
@@ -297,6 +297,30 @@
        * @param cellvolts
        */
       void getVolts(std::array<word, maxCells> &cellvolts) const;
+
+      /**
+       * expose array of temperatures
+       * 0: external temp1; 1: external temp2; 2: internal temp
+       * 3: Thermal shutdown (1 for shutdown 0 for OK)
+       * 4: chip revision!
+       * 
+       * @param temp
+       */
+      void getTemps(std::array<word, 3> &temp) const;
+
+      /**
+       * expose thermal shutdown bit
+       * 
+       * @return thermal shutdown status (1 for shutdown 0 for OK)
+       */
+      bool getTHSD() const;
+
+      /**
+       * expose chip revision
+       * 
+       * @return chip revision
+       */
+      word getChipRevision() const;
       
       // bool operator==(const LTC6802& obj1, const LTC6802& obj2);
       // bool operator!=(const LTC6802& obj1, const LTC6802& obj2);
@@ -702,16 +726,6 @@
        * @param broadcast Send as broadcast to multiple chips
        */
       void measure(const Commands cmd, bool broadcast) const;
-
-      /**
-       * Read register values from chip.
-       *
-       * @param cmd Read command.
-       * @param numOfRegisters Number of registers to read
-       * @param arr Array for register values
-       */
-      template<std::size_t N>
-      void readValues(const Commands cmd, std::array<byte, N> &arr, const bool broadcast);
 
    };
 

--- a/src/LTC6802.h
+++ b/src/LTC6802.h
@@ -52,6 +52,11 @@
         COMP_500MS_MEAS_21MS = 6,
         COMP_2000MS_MEAS_21MS = 7,
       };
+
+      /**
+       * Number of maximum cells connected to LTC6802.
+       */
+      static constexpr byte maxCells = 12;
       
       /**
        * Init SPI bus for LTC6802 chips.
@@ -85,7 +90,7 @@
       /**
        * Read configuration from chip registers.
        */
-      void cfgRead();
+      void cfgRead(const bool broadcast);
 
       /**
        * Write configuration to chip registers.
@@ -135,6 +140,20 @@
        * @param gpio 0 : GPIO2 pin pull down on; 1 : GPIO2 pin pull down off (default)
        */
       void cfgSetGPIO2(bool gpio);
+
+      /**
+       * Get CELL10 bit from configuration.
+       *
+       * @return 0 : 12-cell mode (default); 1 :10-cell mode
+       */
+      bool cfgGetCELL10() const;
+
+      /**
+       * Set cell10 bit: If the CELL10 bit is high, then the inputs for cells 11 and 12 are automatically masked.
+       *
+       * @param cell10 1 : Cell10 on; 0 : cell10 off (default)
+       */
+      void cfgSetCELL10(bool cell10);
 
       /**
        * Get level polling mode from configuration.
@@ -223,12 +242,12 @@
       /**
        * Measure temperatures on chip.
        */
-      void temperatureMeasure();
+      void temperatureMeasure(const bool broadcast);
 
       /**
        * Read temperatures from chip.
        */
-      void temperatureRead();
+      void temperatureRead(const bool broadcast);
 
       /**
        * Write temperatures to serial.
@@ -240,12 +259,12 @@
       /**
        * Measure cell voltages on chip.
        */
-      void cellsMeasure();
+      void cellsMeasure(const bool broadcast);
 
       /**
        * Read cell voltages from chip.
        */
-      void cellsRead();
+      void cellsRead(const bool broadcast);
 
       /**
        * Write cell voltages to serial.
@@ -257,7 +276,7 @@
       /**
        * Read flag register group from chip.
        */
-      void flagsRead();
+      void flagsRead(const bool broadcast);
 
       /**
        * Write flag register group to serial.
@@ -266,6 +285,19 @@
        */
       void flagsDebugOutput();
 
+      /**
+       * Poll for ADC operation complete 
+       * @return busy status, returns false when complete.
+       */
+      bool pollADC(const bool broadcast) const;
+
+      /**
+       * expose array of cell voltage data
+       * 
+       * @param cellvolts
+       */
+      void getVolts(std::array<word, maxCells> &cellvolts) const;
+      
       // bool operator==(const LTC6802& obj1, const LTC6802& obj2);
       // bool operator!=(const LTC6802& obj1, const LTC6802& obj2);
 
@@ -635,11 +667,6 @@
       };
 
       /**
-       * Number of maximum cells connected to LTC6802.
-       */
-      static constexpr byte maxCells = 12;
-
-      /**
        * Chip SPI address.
        */
       byte address;
@@ -666,7 +693,7 @@
        * @param arr Array for register values
        */
       template<std::size_t N>
-      void read(const Commands cmd, std::array<byte, N> &arr);
+      void read(const Commands cmd, std::array<byte, N> &arr, const bool broadcast);
 
       /**
        * Send measure command to chip.
@@ -684,7 +711,7 @@
        * @param arr Array for register values
        */
       template<std::size_t N>
-      void readValues(const Commands cmd, std::array<byte, N> &arr);
+      void readValues(const Commands cmd, std::array<byte, N> &arr, const bool broadcast);
 
    };
 


### PR DESCRIPTION
LTC6802-1 doesn't support addressing, so only works when broadcast is set, I've added the broadcast flag to everything that requires it.

I've also:
* added a getter/setter for the CELL10 bit
* added polling the ADC so you can tell when it's done
* exposed the cell voltage data
* made maxCells public

Please note that C++ isn't my most comfortable language...